### PR TITLE
Implement OpenAPI spec parser with tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "langgraph>=0.0.20",
     "prance[osv]>=23.0.0",
     "jsonschema>=4.0",
-    "requests>=2.25.0",
+    "requests>=2.32.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Summary
Implements an OpenAPI specification parser to extract and process API definitions.

### Changes
- Added OpenAPI spec parsing logic
- Added required dependencies
- Added unit tests covering core parser behavior

### Testing
- pytest
- All existing tests pass
- ~79% coverage for openapi_parser.py

Fixes #4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive OpenAPI 3.x and Swagger 2.0 parser that extracts endpoints, normalizes parameters (including formData/body), and supports filtering by tags and HTTP methods.
  * Added server URL extraction with variable substitution and unified security-scheme extraction.

* **Bug Fixes / Reliability**
  * Improved parsing error reporting for missing/invalid specs.

* **Tests**
  * Added extensive tests covering multiple spec versions, edge cases, and real-world samples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->