### PR TITLE
Fix(config): Harden validation for empty/invalid YAML (#37)

### DIFF
--- a/chaos_kitten/utils/config.py
+++ b/chaos_kitten/utils/config.py
@@ -37,6 +37,12 @@ class Config:
         with open(self.config_path) as f:
             self._config = yaml.safe_load(f)
         
+        if self._config is None:
+            self._config = {}
+            
+        if not isinstance(self._config, dict):
+            raise ValueError("Configuration root must be a mapping/object")
+        
         # Expand environment variables
         self._expand_env_vars(self._config)
         

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,57 @@
+import pytest
+import yaml
+import tempfile
+import os
+from chaos_kitten.utils.config import Config
+
+class TestConfigValidation:
+
+    def create_temp_config(self, content):
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False)
+        tmp.write(content)
+        tmp.close()
+        return tmp.name
+
+    def test_empty_config_file(self):
+        """Test that an empty config file raises a clear ValueError about missing fields, not TypeError."""
+        config_path = self.create_temp_config("")
+        try:
+            config = Config(config_path)
+            with pytest.raises(ValueError, match="Missing required configuration field: target"):
+                config.load()
+        finally:
+            os.remove(config_path)
+
+    def test_invalid_root_list(self):
+        """Test that a list root raises ValueError."""
+        config_path = self.create_temp_config("- item1\n- item2")
+        try:
+            config = Config(config_path)
+            with pytest.raises(ValueError, match="Configuration root must be a mapping/object"):
+                config.load()
+        finally:
+            os.remove(config_path)
+
+    def test_invalid_root_string(self):
+        """Test that a string root raises ValueError."""
+        config_path = self.create_temp_config("just a string")
+        try:
+            config = Config(config_path)
+            with pytest.raises(ValueError, match="Configuration root must be a mapping/object"):
+                config.load()
+        finally:
+            os.remove(config_path)
+
+    def test_valid_config(self):
+        """Test that a valid config loads correctly."""
+        valid_yaml = """
+target:
+  base_url: "http://example.com"
+"""
+        config_path = self.create_temp_config(valid_yaml)
+        try:
+            config = Config(config_path)
+            loaded = config.load()
+            assert loaded["target"]["base_url"] == "http://example.com"
+        finally:
+            os.remove(config_path)


### PR DESCRIPTION
Please add the relevant tags and merge 
Thanks!

- Handle empty config files (None from yaml.safe_load) by defaulting to {}
- Enforce dictionary root structure, raising ValueError for lists/strings
- Added unit tests covering empty, list, and string config cases

Closes #37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Configuration loading enhanced with runtime validation to ensure configurations are properly structured. Invalid configurations now raise clear, informative error messages early in the loading process, preventing downstream processing errors.

* **Tests**
  - New comprehensive test suite validates configuration handling including empty configurations, detection of invalid formats, and successful loading of valid configurations with proper error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->