### PR TITLE
implemented async HTTP executor with auth, retries, and timing

### DIFF
--- a/chaos_kitten/paws/executor.py
+++ b/chaos_kitten/paws/executor.py
@@ -96,7 +96,7 @@ class Executor:
         # Merge headers
         # Start timing
         for attempt in range(max_retries + 1):
-            start_time = time.time()
+            start_time = time.monotonic()
             
             try:
                 # Handle different payload types based on method usually, 
@@ -113,7 +113,7 @@ class Executor:
                         kwargs["params"] = payload
                     
                 response = await self._client.request(method, url, **kwargs)
-                elapsed_ms =  int((time.time() - start_time) * 1000)
+                elapsed_ms =  int((time.monotonic() - start_time) * 1000)
                 
                 return {
                     "status_code": response.status_code,
@@ -124,7 +124,7 @@ class Executor:
                 }
                 
             except httpx.RequestError as e:
-                elapsed_ms = int((time.time() - start_time) * 1000)
+                elapsed_ms = int((time.monotonic() - start_time) * 1000)
                 if attempt == max_retries:
                     return {
                         "status_code": 0,


### PR DESCRIPTION
This PR adds the async HTTP executor that Chaos Kitten uses to actually send attack requests to target APIs.
Closes: #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retry logic (up to 2 attempts) with a short delay between attempts to improve resilience.
  * Extended authorization support to accept OAuth tokens alongside Bearer tokens.
  * Timing now uses monotonic measurements and reports elapsed time in milliseconds.

* **Bug Fixes**
  * Improved error handling for network failures; failures now return elapsed time in milliseconds and clearer error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->