### PR TITLE
fix: remove unsupported oauth type from executor and docs (Types: #38)

### DIFF
--- a/chaos_kitten/cli.py
+++ b/chaos_kitten/cli.py
@@ -37,7 +37,7 @@ target:
   base_url: "http://localhost:3000"
   openapi_spec: "./openapi.json"
   auth:
-    type: "bearer"  # bearer, basic, oauth, none
+    type: "bearer"  # bearer, basic, none
     token: "${API_TOKEN}"
 
 agent:

--- a/chaos_kitten/paws/executor.py
+++ b/chaos_kitten/paws/executor.py
@@ -27,12 +27,19 @@ class Executor:
         
         Args:
             base_url: Base URL of the target API
-            auth_type: Authentication type (bearer, basic, oauth, none)
+            auth_type: Authentication type (bearer, basic, none)
             auth_token: Authentication token/credentials
             rate_limit: Maximum requests per second
             timeout: Request timeout in seconds
+        
+        Raises:
+            ValueError: If auth_type is not supported.
         """
         self.base_url = base_url.rstrip("/")
+        
+        if auth_type not in ["bearer", "basic", "none"]:
+            raise ValueError(f"Unsupported auth_type: {auth_type}. Supported types: bearer, basic, none")
+            
         self.auth_type = auth_type
         self.auth_token = auth_token
         self.rate_limit = rate_limit

--- a/docs/chaos_kitten_prd.md
+++ b/docs/chaos_kitten_prd.md
@@ -51,7 +51,7 @@ Agent Thought: "I'll test negative prices, zero, NaN, and inject SQL strings"
 
 **Capabilities:**
 - Execute HTTP requests asynchronously
-- Support for various authentication methods (Bearer, Basic, OAuth)
+- Support for various authentication methods (Bearer, Basic)
 - Headless browser integration for client-side validation
 - Rate limiting and politeness controls (respect target systems)
 
@@ -173,7 +173,7 @@ target:
   base_url: "http://localhost:3000"
   openapi_spec: "./openapi.json"
   auth:
-    type: "bearer"  # bearer, basic, oauth, none
+    type: "bearer"  # bearer, basic, none
     token: "${API_TOKEN}"
 
 agent:


### PR DESCRIPTION
please add relevant tags and merge
Thanks!


### Type of change
- [x] Bug fix (documentation/code mismatch)
- [ ] New feature
- [x] Documentation update

### Description
This PR addresses issue #38 by removing references to the currently unsupported `oauth` authentication type. The `Executor` was previously documented as supporting OAuth, but the code only handled Bearer and Basic authentication. 

I have:
1.  Removed `oauth` from the configuration template generated by `chaos-kitten init`.
2.  Updated the `Executor` class to raise a `ValueError` if an unsupported auth type is passed.
3.  Updated the PRD and docstrings to reflect the actual capabilities (Bearer, Basic, None).

### Testing
- Verified that `Executor(..., auth_type='oauth')` now raises a clear `ValueError`.
- Verified that `chaos-kitten init` generates a config file listing only supported types.

### Checklist
- [x] Code compiles/runs
- [x] Documentation updated
- [x] Tests passed (manual verification)


closes #38 