### PR TITLE
Added common passwords with purpose, source and disclaimer.

### DIFF
--- a/toys/data/common_passwords.txt
+++ b/toys/data/common_passwords.txt
@@ -5,7 +5,8 @@
 # passwords on authorized targets.
 
 # Source Attribution:
-# Passwords in this list are derived from publicly available security resources.
+# Passwords in this list are derived from publicly available security resources,
+# including historical breach analyses (e.g., RockYou).
 
 # Legal & Ethical Usage Disclaimer:
 # This wordlist is provided strictly for EDUCATIONAL, DEFENSIVE, and AUTHORIZED


### PR DESCRIPTION
This PR adds the common passwords in the common_passwords.txt file under toys/data/.
The file contains a categorized list of common, weak, and default passwords . All passwords in this list are derived from available security resources.

closes #76 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded the common-password wordlist significantly (~+500 lines) with many new entries across categories (most-common, vendor defaults, keyboard patterns, common patterns, empty/null variants) and removed several outdated or weak entries to improve detection and validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->