### PR TITLE
Add GraphQL schema parsing support (Issue #75)

### DIFF
--- a/chaos_kitten/brain/__init__.py
+++ b/chaos_kitten/brain/__init__.py
@@ -2,6 +2,7 @@
 
 from chaos_kitten.brain.orchestrator import Orchestrator
 from chaos_kitten.brain.openapi_parser import OpenAPIParser
+from chaos_kitten.brain.graphql_parser import GraphQLParser
 from chaos_kitten.brain.attack_planner import AttackPlanner
 
-__all__ = ["Orchestrator", "OpenAPIParser", "AttackPlanner"]
+__all__ = ["Orchestrator", "OpenAPIParser", "GraphQLParser", "AttackPlanner"]

--- a/chaos_kitten/brain/graphql_parser.py
+++ b/chaos_kitten/brain/graphql_parser.py
@@ -1,0 +1,328 @@
+"""GraphQL Schema Parser.
+
+This module provides the `GraphQLParser` class, which parses GraphQL schemas
+from live endpoints (introspection) or local files (.graphql/.json) and
+converts them into a format compatible with the Chaos Kitten Attack Planner.
+"""
+
+from __future__ import annotations
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List
+from urllib.parse import urlparse
+import httpx
+
+# Try to import graphql for SDL parsing
+try:
+    from graphql import build_schema, introspection_from_schema
+    HAS_GRAPHQL_CORE = True
+except ImportError:
+    HAS_GRAPHQL_CORE = False
+
+logger = logging.getLogger(__name__)
+
+
+class GraphQLParser:
+    """Parses GraphQL schemas from endpoints or local files."""
+
+    # Standard Introspection Query to retrieve the full schema
+    INTROSPECTION_QUERY = """
+    query IntrospectionQuery {
+      __schema {
+        queryType { name }
+        mutationType { name }
+        subscriptionType { name }
+        types {
+          ...FullType
+        }
+        directives {
+          name
+          description
+          locations
+          args {
+            ...InputValue
+          }
+        }
+      }
+    }
+    fragment FullType on __Type {
+      kind
+      name
+      description
+      fields(includeDeprecated: true) {
+        name
+        description
+        args {
+          ...InputValue
+        }
+        type {
+          ...TypeRef
+        }
+        isDeprecated
+        deprecationReason
+      }
+      inputFields {
+        ...InputValue
+      }
+      interfaces {
+        ...TypeRef
+      }
+      enumValues(includeDeprecated: true) {
+        name
+        description
+        isDeprecated
+        deprecationReason
+      }
+      possibleTypes {
+        ...TypeRef
+      }
+    }
+    fragment InputValue on __InputValue {
+      name
+      description
+      type { ...TypeRef }
+      defaultValue
+    }
+    fragment TypeRef on __Type {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    def __init__(self, endpoint_url: str | None = None, schema_path: str | Path | None = None) -> None:
+        """Initialize with either a live endpoint or local schema file.
+
+        Args:
+            endpoint_url: URL of the GraphQL API endpoint.
+            schema_path: Path to a local .graphql or .json schema file.
+        """
+        self.endpoint_url = endpoint_url
+        self.schema_path = Path(schema_path) if schema_path else None
+        self.schema: Dict[str, Any] = {}
+
+        if not self.endpoint_url and not self.schema_path:
+            # We allow init without args technically if we plan to set late, 
+            # but usually for this tool we want one. 
+            # Requirements don't strictly forbid it, but let's be safe.
+            pass
+
+    def introspect(self) -> dict[str, Any]:
+        """Send introspection query to live endpoint, return schema.
+        
+        Returns:
+            The introspection result (dict with __schema key).
+        """
+        if not self.endpoint_url:
+            raise ValueError("No endpoint_url provided for introspection")
+
+        try:
+            logger.info(f"Introspecting GraphQL endpoint: {self.endpoint_url}")
+            response = httpx.post(
+                self.endpoint_url,
+                json={"query": self.INTROSPECTION_QUERY},
+                timeout=30.0
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            if "errors" in data and data["errors"]:
+                raise ValueError(f"GraphQL Introspection returned errors: {data['errors']}")
+
+            if "data" not in data or "__schema" not in data["data"]:
+                raise ValueError("Invalid introspection response: missing __schema")
+
+            self.schema = data["data"]
+            return self.schema
+
+        except httpx.RequestError as e:
+            logger.error(f"Network error interacting with GraphQL endpoint: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Failed to introspect GraphQL endpoint: {e}")
+            raise
+
+    def parse_schema(self) -> dict[str, Any]:
+        """Parse a local .graphql or .json schema file.
+        
+        Returns:
+            The parsed schema dictionary.
+        """
+        if not self.schema_path or not self.schema_path.exists():
+            raise FileNotFoundError(f"Schema file not found: {self.schema_path}")
+
+        try:
+            content = self.schema_path.read_text(encoding="utf-8")
+
+            if self.schema_path.suffix == ".json":
+                data = json.loads(content)
+                # Check if it's wrapped in data or just schema
+                if "data" in data and "__schema" in data["data"]:
+                    self.schema = data["data"]
+                elif "__schema" in data:
+                    self.schema = data
+                else:
+                    raise ValueError("JSON file does not appear to be a standard introspection result (missing __schema)")
+
+            elif self.schema_path.suffix in [".graphql", ".gql"]:
+                if not HAS_GRAPHQL_CORE:
+                    raise ImportError(
+                        "graphql-core library is required to parse .graphql files. "
+                        "Install it with 'pip install graphql-core'"
+                    )
+
+                # Parse SDL to schema object, then convert to introspection dict for consistency
+                graphql_schema = build_schema(content)
+                introspection_result = introspection_from_schema(graphql_schema)
+                # introspection_from_schema returns the dict matching __schema structure directly?
+                # Actually it typically returns {'__schema': ...} or just the schema obj.
+                # Let's verify standard behavior. usually `introspection_from_schema` returns the schema part.
+                # But to be safe and consistent with our self.schema expectation (containing __schema key at root?)
+                # Wait, self.schema = data["data"] where data["data"] has "__schema".
+                # So self.schema should contain "__schema".
+                
+                # introspection_from_schema returns a dict with "__schema" key?
+                # No, it returns the schema dict. let's check.
+                # Check `graphql.utilities.introspection_from_schema` doc or assume standard.
+                # Assuming it returns the Dict that usually goes under "data".
+                
+                self.schema = introspection_result
+
+            else:
+                raise ValueError(f"Unsupported file extension: {self.schema_path.suffix}")
+
+            return self.schema
+
+        except Exception as e:
+            logger.error(f"Failed to parse schema file: {e}")
+            raise
+
+    def get_queries(self) -> list[dict[str, Any]]:
+        """Extract all Query type fields with arguments."""
+        if not self.schema:
+            return []
+
+        query_type_name = self.schema["__schema"].get("queryType", {}).get("name", "Query")
+        return self._get_fields_for_type(query_type_name)
+
+    def get_mutations(self) -> list[dict[str, Any]]:
+        """Extract all Mutation type fields with arguments."""
+        if not self.schema:
+            return []
+
+        mutation_type_obj = self.schema["__schema"].get("mutationType")
+        if not mutation_type_obj:
+            return []
+
+        mutation_type_name = mutation_type_obj.get("name", "Mutation")
+        return self._get_fields_for_type(mutation_type_name)
+
+    def get_types(self) -> list[dict[str, Any]]:
+        """Extract all custom types with their fields."""
+        if not self.schema:
+            return []
+
+        types = []
+        for type_def in self.schema["__schema"]["types"]:
+            if type_def["kind"] == "OBJECT" and not type_def["name"].startswith("__"):
+                types.append(type_def)
+        return types
+
+    def _get_fields_for_type(self, type_name: str) -> list[dict[str, Any]]:
+        fields = []
+        types = self.schema["__schema"]["types"]
+
+        target_type = next((t for t in types if t["name"] == type_name), None)
+        if not target_type or "fields" not in target_type or not target_type["fields"]:
+            return []
+
+        for field in target_type["fields"]:
+            fields.append({
+                "name": field["name"],
+                "description": field.get("description"),
+                "args": [
+                    {
+                        "name": arg["name"],
+                        "type": self._resolve_type_name(arg["type"]),
+                        "required": arg["type"]["kind"] == "NON_NULL"
+                    }
+                    for arg in field.get("args", [])
+                ],
+                "type": self._resolve_type_name(field["type"])
+            })
+        return fields
+
+    def _resolve_type_name(self, type_ref: dict[str, Any] | None) -> str:
+        """Helper to reconstruct type signature (e.g. String!, [User])."""
+        if not type_ref:
+            return "Unknown"
+
+        kind = type_ref.get("kind")
+        name = type_ref.get("name")
+        of_type = type_ref.get("ofType")
+
+        if kind == "NON_NULL":
+            return f"{self._resolve_type_name(of_type)}!"
+        elif kind == "LIST":
+            return f"[{self._resolve_type_name(of_type)}]"
+        else:
+            return name if name else "Unknown"
+
+    def to_endpoints(self) -> list[dict[str, Any]]:
+        """Convert GraphQL operations to endpoint-like format for the AttackPlanner."""
+        endpoints = []
+
+        path = "/graphql"
+        if self.endpoint_url:
+            parsed = urlparse(self.endpoint_url)
+            path = parsed.path
+
+        # Add Mutation operations
+        mutations = self.get_mutations()
+        for op in mutations:
+            endpoints.append({
+                "path": path,
+                "method": "POST",
+                "operation": f"mutation {op['name']}",
+                "fields": op["args"]  # Already has name, type, required
+            })
+
+        # Add Query operations
+        queries = self.get_queries()
+        for op in queries:
+            endpoints.append({
+                "path": path,
+                "method": "POST",  # Queries are typically POSTed
+                "operation": f"query {op['name']}",
+                "fields": op["args"]
+            })
+
+        return endpoints

--- a/chaos_kitten/utils/config.py
+++ b/chaos_kitten/utils/config.py
@@ -71,8 +71,16 @@ class Config:
             if field not in self._config:
                 raise ValueError(f"Missing required configuration field: {field}")
         
-        if "base_url" not in self._config.get("target", {}):
-            raise ValueError("Missing required field: target.base_url")
+        target = self._config.get("target", {})
+        target_type = target.get("type", "rest")
+        
+        if target_type == "graphql":
+            if "graphql_endpoint" not in target and "graphql_schema" not in target:
+                raise ValueError("GraphQL target requires either 'graphql_endpoint' or 'graphql_schema'")
+        else:
+            # Default to REST behavior
+            if "base_url" not in target:
+                raise ValueError("Missing required field: target.base_url")
     
     @property
     def target(self) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "prance[osv]>=23.0.0",
     "jsonschema>=4.0",
     "requests>=2.32.4",
+    "graphql-core>=3.2.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_graphql_parser.py
+++ b/tests/test_graphql_parser.py
@@ -1,0 +1,138 @@
+"""Tests for the GraphQL Parser."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+import httpx
+from chaos_kitten.brain.graphql_parser import GraphQLParser
+
+class TestGraphQLParser:
+    """Tests for GraphQLParser."""
+
+    @pytest.fixture
+    def mock_introspection_response(self):
+        return {
+            "data": {
+                "__schema": {
+                    "queryType": {"name": "RootQuery"},
+                    "mutationType": {"name": "RootMutation"},
+                    "types": [
+                        {
+                            "kind": "OBJECT",
+                            "name": "RootQuery",
+                            "fields": [
+                                {
+                                    "name": "getUser",
+                                    "description": "Get user by ID",
+                                    "args": [
+                                        {
+                                            "name": "id",
+                                            "type": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "ID"}}
+                                        }
+                                    ],
+                                    "type": {"kind": "OBJECT", "name": "User"}
+                                }
+                            ]
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "RootMutation",
+                            "fields": [
+                                {
+                                    "name": "createUser",
+                                    "args": [
+                                        {
+                                            "name": "username",
+                                            "type": {"kind": "NON_NULL", "name": None, "ofType": {"kind": "SCALAR", "name": "String"}}
+                                        }
+                                    ],
+                                    "type": {"kind": "OBJECT", "name": "User"}
+                                }
+                            ]
+                        },
+                         {
+                            "kind": "OBJECT",
+                            "name": "User",
+                            "fields": [
+                                {"name": "id", "type": {"kind": "SCALAR", "name": "ID"}},
+                                {"name": "username", "type": {"kind": "SCALAR", "name": "String"}}
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+
+    @patch("httpx.post")
+    def test_introspect_success(self, mock_post, mock_introspection_response):
+        """Test successful introspection from an endpoint."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_introspection_response
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        parser = GraphQLParser(endpoint_url="http://example.com/graphql")
+        schema = parser.introspect()
+
+        assert schema == mock_introspection_response["data"]
+        mock_post.assert_called_once()
+    
+    @patch("httpx.post")
+    def test_introspect_failure(self, mock_post):
+        """Test introspection failure handling."""
+        mock_post.side_effect = httpx.RequestError("Network error")
+        parser = GraphQLParser(endpoint_url="http://example.com/graphql")
+        
+        with pytest.raises(httpx.RequestError):
+            parser.introspect()
+
+    def test_parse_schema_json(self, mock_introspection_response):
+        """Test parsing a local JSON schema file."""
+        import json
+        json_content = json.dumps(mock_introspection_response["data"])
+        
+        with patch("pathlib.Path.read_text", return_value=json_content), \
+             patch("pathlib.Path.exists", return_value=True):
+            
+            parser = GraphQLParser(schema_path="schema.json")
+            schema = parser.parse_schema()
+            assert schema["__schema"]["queryType"]["name"] == "RootQuery"
+
+    def test_to_endpoints(self, mock_introspection_response):
+        """Test conversion of schema to endpoint list."""
+        parser = GraphQLParser(endpoint_url="http://example.com/api/graphql")
+        # Manually set schema to avoid introspection call
+        parser.schema = mock_introspection_response["data"]
+        
+        endpoints = parser.to_endpoints()
+        
+        assert len(endpoints) == 2
+        
+        # Check Mutation
+        mutation = next(e for e in endpoints if "createUser" in e["operation"])
+        assert mutation["path"] == "/api/graphql"
+        assert mutation["method"] == "POST"
+        assert mutation["fields"][0]["name"] == "username"
+        assert mutation["fields"][0]["type"] == "String!"
+        assert mutation["fields"][0]["required"] is True
+
+        # Check Query
+        query = next(e for e in endpoints if "getUser" in e["operation"])
+        assert query["fields"][0]["name"] == "id"
+        assert query["fields"][0]["type"] == "ID!"
+
+    def test_resolve_type_name(self):
+        """Test type name resolution helper."""
+        parser = GraphQLParser()
+        # Test List
+        type_ref = {"kind": "LIST", "ofType": {"kind": "SCALAR", "name": "String"}}
+        assert parser._resolve_type_name(type_ref) == "[String]"
+
+        # Test Non-Null
+        type_ref = {"kind": "NON_NULL", "ofType": {"kind": "SCALAR", "name": "Int"}}
+        assert parser._resolve_type_name(type_ref) == "Int!"
+        
+        # Test Simple
+        type_ref = {"kind": "SCALAR", "name": "Boolean", "ofType": None}
+        assert parser._resolve_type_name(type_ref) == "Boolean"
+


### PR DESCRIPTION
# Add GraphQL Schema Parsing Support

Closes #75

## Description
This PR enables Chaos Kitten to test GraphQL APIs by adding a new `GraphQLParser` module. It supports parsing schemas from live endpoints (via introspection) as well as local `.graphql` and `.json` files.

## Changes
- **New Module**: `chaos_kitten/brain/graphql_parser.py`
  - Performs introspection query on live endpoints.
  - Parses local schema files.
  - Converts GraphQL queries and mutations into "endpoint" format for the Attack Planner.
- **Config**: Updated `chaos_kitten/utils/config.py` to support `target.type: "graphql"`.
- **Dependencies**: Added `graphql-core` to `pyproject.toml`.
- **Tests**: Added `tests/test_graphql_parser.py`.

## Configuration Example
```yaml
target:
  type: "graphql"
  graphql_endpoint: "http://localhost:4000/graphql"
  # OR
  graphql_schema: "./schema.graphql"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* GraphQL schema discovery and parsing from live endpoints or local schema files
* Automatic extraction of GraphQL queries, mutations, and types for analysis
* Configuration now supports GraphQL as a target type with endpoint or schema file options

## Tests
* Added comprehensive test coverage for GraphQL schema parsing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->