### PR TITLE
Add CSRF attack profile

### DIFF
--- a/toys/csrf.yaml
+++ b/toys/csrf.yaml
@@ -48,3 +48,7 @@ remediation: |
   Use SameSite cookie attributes (Strict or Lax).
   Avoid using GET requests for sensitive actions.
   Require re-authentication or confirmation for critical operations.
+
+references:
+  - "https://owasp.org/www-community/attacks/csrf"
+  - "https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html"


### PR DESCRIPTION
Adds toys/csrf.yaml following existing SQL injection profile structure.
Includes payloads, indicators, remediation, and references.
closes #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CSRF vulnerability testing configuration with example attack patterns (auto-submit forms, image-based GET, JavaScript requests), detection indicators (response terms and status codes), and practical remediation guidance (anti-CSRF tokens, Origin/Referer checks, SameSite cookies, avoid GET for state changes) with OWASP references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->