### PR TITLE
Create XXE Injection attack profile

### DIFF
--- a/toys/xxe_injection.yaml
+++ b/toys/xxe_injection.yaml
@@ -218,7 +218,7 @@ payloads:
   - |
     <?xml version="1.0"?>
     <!DOCTYPE foo [
-      <!ENTITY xxe SYSTEM "gopher://localhost:6379/_PING">
+      <!ENTITY xxe SYSTEM "gopher://localhost:6379/_PING%0D%0A">
     ]>
     <foo>&xxe;</foo>
 


### PR DESCRIPTION
### PR Description

**Title:** Create XXE (XML External Entity) Injection Attack Profile

**Description:**
This PR adds the `toys/xxe_injection.yaml` attack profile as requested in #89. 

It renames the existing `toys/xxe.yaml` to `toys/xxe_injection.yaml` and expands it to include **over 25 unique attack payloads** across all required categories:
- **File Read Attacks**: Linux (`/etc/passwd`, `/proc/self/cmdline`), Windows (`win.ini`, `boot.ini`).
- **External Entity Injection**: Basic and parameterized entities.
- **DTD-based DoS**: Billion Laughs attack.
- **SSRF via XXE**: Internal scanning (ports 22, 8080, 3306) and Cloud Metadata (AWS, GCP, Azure).
- **Blind XXE**: Out-of-band exfiltration via FTP and HTTP.
- **Advanced Protocols**: `gopher://`, `jar:`, `netdoc:/`, `expect://`, `php://filter`.

It also includes:
- **Target fields**: `xml`, `document`, `data`, `content`.
- **Success indicators**: Specific file strings and error messages.
- **Remediation**: Comprehensive Java, Python, PHP, and C# code examples for safe XML parsing (disabling DTDs).

**Fixes:** #89 

**Verification:**
1. Check that `toys/xxe_injection.yaml` exists and `toys/xxe.yaml` is removed.
2. Verify it contains payloads for File Read, SSRF, DoS, and Blind XXE.
3. Confirm remediation examples are present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added numerous XXE injection test payloads to broaden coverage of external-resource vectors (HTTP, file, gopher, jar, netdoc, FTP, and PHP filter variants).
  * Expanded payloads to include common internal service endpoints and multiple local file-path variants for more comprehensive validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->