### PR TITLE
feat(toys): add rate limiting and account lockout bypass profile #94

### DIFF
--- a/toys/ratelimit_bypass.yaml
+++ b/toys/ratelimit_bypass.yaml
@@ -20,7 +20,7 @@ payloads:
   # Category 1: Header Manipulation
   - "127.0.0.1"
   - "::1"
-  - "" # empty string
+  - ""              # empty string
   - "0.0.0.0"
   - "localhost"
   - "192.168.1.1"
@@ -48,14 +48,14 @@ payloads:
   - "adm\u00efn" # Unicode lookalike
   - " admin" # Leading space
 
-  # Category 5: Timing / Distributed Bypass (Add 5+)
-  - "X-Request-ID: chaos-timing-001"
-  - "X-Correlation-ID: chaos-timing-001"
-  - "X-Request-ID: chaos-timing-001" # Duplicate — tests idempotency / per-request counters
-  - "X-Forwarded-Host: localhost"
-  - "X-Original-URL: /admin"
+  # Category 5: Timing / Distributed Bypass
+  - "chaos-bypass-001"        # Unique request ID value to probe counter-reset per ID
+  - "chaos-bypass-002"
+  - "0"                       # Attempt to override RateLimit-Remaining hint
+  - "9999"                    # Attempt to spoof limit hint value
+  - "bypass-seq-{{random}}"   # Placeholder for sequential/random ID if runner supports it
 
-  # Category 6: Cache Bypass (Add 5+)
+  # Category 6: Cache Bypass
   - "no-cache"
   - "no-store, must-revalidate"
   - "max-age=0"


### PR DESCRIPTION
Description
This PR adds a new attack profile for Rate Limiting and Account Lockout Bypass to the toys/ directory. This profile allows the Chaos Kitten orchestrator to intelligently test if an API can be tricked into resetting its rate limits or account lockout counters using various header and parameter manipulation techniques.

**Changes**

- Created toys/ratelimit_bypass.yaml.
- Added 9 target headers (including X-Forwarded-For, True-Client-IP, and CF-Connecting-IP).
- Implemented 30 unique payloads across all 6 required categories:
  1. Header IP Spoofing
  2. Multi-Header Bypass
  3. Parameter Variation
  4. Account Lockout Bypass (using whitespace, case, and unicode)
  5. Timing / Strategy Hints
  6. Cache Bypass.

- Included detailed remediation guidance and references to OWASP API4:2023 and CWE-307.

**Verification**
[x] Validated the file using yamllint.
[x] Verified it meets all 20+ payload requirements from the issue description.
[x] Confirmed the file is correctly placed in the toys/ folder.

Closes #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bundled test suite for rate-limit and account-lockout bypass techniques, covering header manipulation, multi-header methods, parameter variations, spacing/case/Unicode variants, timing/distributed patterns, and cache-bypass approaches.
  * Includes built-in success-detection hints (status codes and response cues) and remediation guidance with security references to assist hardening and analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->