### PR TITLE
Fixed get_servers Variable Substitution Failure (Closes#137)

### DIFF
--- a/chaos_kitten/brain/openapi_parser.py
+++ b/chaos_kitten/brain/openapi_parser.py
@@ -317,9 +317,24 @@ class OpenAPIParser:
                 variables = server_obj.get('variables', {})
                 
                 # Perform variable substitution
-                # Uses default value if available
+                # Uses default value if available, falls back to first enum value
                 for var_name, var_info in variables.items():
-                    default_val = var_info.get('default', '')
+                    if 'default' in var_info:
+                        default_val = var_info['default']
+                    elif 'enum' in var_info and var_info['enum']:
+                        default_val = var_info['enum'][0]
+                        logger.warning(
+                            "Server variable '%s' has no default; "
+                            "falling back to first enum value: %s",
+                            var_name, default_val,
+                        )
+                    else:
+                        default_val = ''
+                        logger.warning(
+                            "Server variable '%s' has no default or enum values; "
+                            "substituting empty string",
+                            var_name,
+                        )
                     url = url.replace(f"{{{var_name}}}", str(default_val))
                 
                 servers.append(url)


### PR DESCRIPTION
The bug: In openapi_parser.py line 322, var_info.get('default', '') substituted an empty string when a server URL variable had enum values but no default, producing broken URLs like https://api.example.com//v1.

The fix: Variable substitution now:

Uses default if present (existing behavior)
Falls back to enum[0] if default is missing but enum exists
Logs a warning in both fallback cases
Verified: All 16 OpenAPIParser tests pass, including test_get_servers_openapi_3_with_variables.

Closes #137 


<img width="1129" height="668" alt="image" src="https://github.com/user-attachments/assets/d538506b-28eb-4ed1-ba34-f8b51ddd37e3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced comprehensive SSRF attack profile for security testing, including attack payloads covering common vulnerable scenarios, detection indicators, and detailed remediation recommendations.

* **Bug Fixes**
  * Enhanced server variable substitution logic with improved fallback handling that gracefully manages missing defaults and provides detailed warning messages for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->