### PR TITLE
 Fix: Replace broken semaphore rate limiter with asyncio.Lock throttle (Closes #191)

### DIFF
--- a/chaos_kitten/paws/executor.py
+++ b/chaos_kitten/paws/executor.py
@@ -90,7 +90,7 @@ class Executor:
         self.log_file = log_file
 
         self._client: Optional[httpx.AsyncClient] = None
-        self._rate_limiter: Optional[asyncio.Semaphore] = None
+        self._rate_lock: Optional[asyncio.Lock] = None
         self._last_request_time: float = 0.0
         self.totp_secret = totp_secret
         self.totp_endpoint = totp_endpoint
@@ -109,8 +109,8 @@ class Executor:
         
         await self._perform_mfa_auth()
         
-        # Initialize rate limiter semaphore
-        self._rate_limiter = asyncio.Semaphore(max(1, self.rate_limit)) if self.rate_limit > 0 else None
+        # Initialize rate limiter lock
+        self._rate_lock = asyncio.Lock() if self.rate_limit > 0 else None
         return self
     
     async def __aexit__(self, *args: Any) -> None:
@@ -350,24 +350,28 @@ class Executor:
         await asyncio.sleep(backoff)
 
     async def _apply_rate_limit(self) -> None:
-        """Apply rate limiting using token bucket algorithm."""
-        if not self._rate_limiter:
+        """Enforce a minimum interval between requests (1 / rate_limit seconds).
+
+        Uses an asyncio.Lock to serialise the timing check so that
+        concurrent callers are properly spaced apart.  The lock is
+        released *after* the timestamp is updated but *before* the
+        actual HTTP request runs, which is the correct pattern for a
+        leaky-bucket rate limiter (as opposed to a concurrency limiter).
+        """
+        if not self._rate_lock:
             return
-        
-        # Acquire semaphore token
-        async with self._rate_limiter:
-            # Calculate time since last request
-            current_time = time.perf_counter()
-            time_since_last = current_time - self._last_request_time
-            
-            # Minimum time between requests (in seconds)
-            min_interval = 1.0 / self.rate_limit if self.rate_limit > 0 else 0
-            
-            # Sleep if we're going too fast
-            if time_since_last < min_interval:
-                await asyncio.sleep(min_interval - time_since_last)
-            
-            # Update last request time
+
+        min_interval = 1.0 / self.rate_limit if self.rate_limit > 0 else 0
+
+        async with self._rate_lock:
+            # Calculate how long to wait before this request may proceed
+            now = time.perf_counter()
+            elapsed = now - self._last_request_time
+            if elapsed < min_interval:
+                await asyncio.sleep(min_interval - elapsed)
+
+            # Stamp the time *before* releasing the lock so the next
+            # waiter uses the correct baseline.
             self._last_request_time = time.perf_counter()
 
     def _setup_logging(self) -> None:


### PR DESCRIPTION
 Fix: Replace broken semaphore rate limiter with asyncio.Lock throttle

Closes #191

 Problem

`_apply_rate_limit` in `executor.py` acquires an `asyncio.Semaphore`, sleeps inside it, then releases it — but the actual HTTP request runs outside the semaphore. This means:

- All requests that were queued during the sleep fire simultaneously once the semaphore is released
- The semaphore does not gate concurrent requests at all
- `Semaphore(rate_limit)` conflates "max concurrent requests" with "requests per second", which are different concepts

 Fix

- Replaced `asyncio.Semaphore` with `asyncio.Lock` to serialize the timing check
- Each caller acquires the lock, checks how long since the last request, sleeps if needed to enforce the minimum interval (1 / rate_limit seconds), stamps the time, then releases the lock
- The HTTP request runs after the lock is released, but since the timestamp is updated before releasing, the next waiter computes the correct delay
- This implements a proper leaky-bucket rate limiter that spaces requests evenly

 Changes

- `executor.py`
    - `_rate_limiter: Semaphore` replaced with `_rate_lock: Lock`
    - `__aenter__` initializes `asyncio.Lock()` instead of `asyncio.Semaphore(rate_limit)`
    - `_apply_rate_limit` rewritten with correct leaky-bucket logic and updated docstring

 How It Works

Before (broken):
1. Acquire semaphore
2. Sleep inside semaphore
3. Release semaphore
4. Send HTTP request (all queued requests fire at once here)

After (fixed):
1. Acquire lock
2. Calculate delay from last request timestamp
3. Sleep if needed to maintain 1/rate_limit spacing
4. Update timestamp
5. Release lock
6. Send HTTP request (properly spaced apart)

 Testing

- All 33 chaos engine tests pass
- Syntax verified OK
- No new dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TOTP field configuration in initialization.

* **Refactor**
  * Improved rate limiting mechanism to use lock-based synchronization for more reliable request timing control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->