### PR TITLE
Fixed Dead Code Block After preflight() References Undefined Variables (Closes #207)

### DIFF
--- a/chaos_kitten/cli.py
+++ b/chaos_kitten/cli.py
@@ -442,39 +442,6 @@ def preflight():
         console.print("\n[bold green]✅ Environment is ready for basic scanning![/bold green]")
 
 
-    from chaos_kitten.brain.orchestrator import Orchestrator
-
-    orchestrator = Orchestrator(app_config)
-    try:
-        import asyncio
-        results = asyncio.run(orchestrator.run())
-
-        # Check for orchestrator runtime errors
-        if isinstance(results, dict) and results.get("status") == "failed":
-            console.print(f"[bold red]❌ Scan failed:[/bold red] {results.get('error')}")
-            raise typer.Exit(code=1)
-
-        # Handle --fail-on-critical (including pre-scan findings)
-        if fail_on_critical:
-            vulnerabilities = results.get("vulnerabilities", [])
-            critical_vulns = [
-                v for v in vulnerabilities 
-                if str(v.get("severity", "")).lower() == "critical"
-            ]
-            # Note: orchestrator already injected critical_findings into vulnerabilities, so no need to add again
-            total_critical = len(critical_vulns)
-            
-            if total_critical > 0:
-                console.print(f"[bold red]❌ Found {total_critical} critical issue(s). Failing pipeline.[/bold red]")
-                raise typer.Exit(code=1)
-
-    except typer.Exit:
-        raise
-    except Exception as e:
-        console.print(f"[bold red]❌ Diff scan failed:[/bold red] {e}")
-        raise typer.Exit(code=1)
-
-
 @app.command()
 def interactive():
     """Start interactive mode."""


### PR DESCRIPTION
Closes #207

Problem
After the preflight() command finishes printing its dependency table in cli.py, there was an orphaned code block (lines 444–475) that:

Imported Orchestrator and referenced app_config — a variable that did not exist in preflight()'s scope (it exists only in scan()).
Referenced fail_on_critical — another variable that belongs to the diff() command, not preflight().
Ran orchestrator.run() and checked for critical vulnerabilities.
This code was accidentally copy-pasted from diff() and resulted in a NameError crash whenever the user had nmap installed (since execution would fall through after the table output).

🛠️ Fix
Removed the dead code block entirely (lines 444–475).
preflight() now correctly displays the dependency status table and exits cleanly as intended.

🧪 Testing
Ran python chaos_kitten/cli.py preflight to confirm the dependency table prints successfully.
Verified that the command exits cleanly without any NameError exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Preflight has been streamlined to exclusively handle dependency verification and readiness validation. Removed automatic scanning and orchestration execution from the preflight phase. Simplified related error handling to provide clearer separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->