### PR TITLE
Fixed ResponseAnalyzer._check_custom_indicators Silently Miscompares Timing Units #208

### DIFF
--- a/chaos_kitten/paws/analyzer.py
+++ b/chaos_kitten/paws/analyzer.py
@@ -255,13 +255,16 @@ class ResponseAnalyzer:
         return None
 
     def _check_custom_indicators(self, response: dict, indicators: dict) -> Optional[Finding]:
-        """Check against success indicators defined in the attack profile."""
+        """Check against success indicators defined in the attack profile.
+        
+        Note: The `response_time_gt` indicator is expected to be in seconds.
+        """
         if not indicators:
             return None
             
         body = response.get("body", "")
         status_code = response.get("status_code")
-        elapsed_ms = response.get("elapsed_ms", 0) / 1000.0  # convert to seconds
+        elapsed_s = response.get("elapsed_ms", 0) / 1000.0  # convert to seconds
 
         # Check response_contains
         if "response_contains" in indicators:
@@ -288,10 +291,10 @@ class ResponseAnalyzer:
         # Check response_time_gt
         if "response_time_gt" in indicators:
             limit = indicators["response_time_gt"]
-            if elapsed_ms > limit:
+            if elapsed_s > limit:
                  return Finding(
                     vulnerability_type="",
-                    evidence=f"Response time {elapsed_ms:.2f}s > {limit}s",
+                    evidence=f"Response time {elapsed_s:.2f}s > {limit}s",
                     confidence=0.8
                 )
 


### PR DESCRIPTION
Closes #208

 🐛 Problem

In `ResponseAnalyzer._check_custom_indicators`, the code divided `elapsed_ms` by 1000 to convert it to seconds, but kept the variable name `elapsed_ms`. It then compared this value against `response_time_gt` from the attack profiles. Because the variable was still named `elapsed_ms`, it created confusion and could lead to silent false negatives if a profile author expected the unit to be milliseconds. 

Additionally, the `check_timing_anomalies` method within the same class expects milliseconds, making the timing units inconsistent across the class.

 🛠️ Fix

- Audited the attack profiles and confirmed that `response_time_gt` is documented and expected to be in seconds.
- Renamed the `elapsed_ms` variable to `elapsed_s` in `_check_custom_indicators` after the division. This makes the unit explicit and prevents confusion.
- Added a clarifying docstring to `_check_custom_indicators` noting that the `response_time_gt` indicator requires its value in seconds.
- Verified that `check_timing_anomalies` correctly evaluates `elapsed_ms` and `baseline_ms` in milliseconds.

 🧪 Testing

- Verified all 13 tests in `test_response_analyzer.py` pass cleanly.
- Verified that `response_time_gt` correctly triggers when `elapsed_s` exceeds the limit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized response time measurement units in performance analysis to ensure consistent timing comparisons across all evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->