### PR TITLE
Fixed NameError in scan CORS Probe when target_url is undefined (Closes #206)

### DIFF
--- a/chaos_kitten/cli.py
+++ b/chaos_kitten/cli.py
@@ -229,14 +229,15 @@ def scan(
         results = asyncio.run(orchestrator.run())
 
         # CORS Check from HEAD
-        if cors and target_url:
+        resolved_target = target or app_config.get("target", {}).get("base_url")
+        if cors and resolved_target:
             import httpx, asyncio
             from chaos_kitten.brain.cors import analyze_cors
             
             async def _cors_probe():
                 async with httpx.AsyncClient() as client:
                     try:
-                        resp = await client.get(target_url, headers={"Origin": "https://evil.example"}, timeout=10.0)
+                        resp = await client.get(resolved_target, headers={"Origin": "https://evil.example"}, timeout=10.0)
                         return dict(resp.headers)
                     except Exception as e:
                         if not silent:


### PR DESCRIPTION
Problem
When running chaos-kitten scan --cors -t http://example.com, the CORS probe implementation referenced target_url, a variable that did not exist in the scan() function's scope. The CLI parameter is actually target, not target_url. This caused an immediate NameError, completely breaking the --cors flag functionality.

Fix
Replaced target_url with a resolved_target variable in cli.py.
Formulated resolved_target to robustly use either the passed target CLI parameter or the value falling back to app_config.get("target", {}).get("base_url").
Added a guard to ensure the CORS probe is only executed if resolved_target is actually available.

Testing
Syntax verified cleanly via AST.
Ensured no regression of the base config-loading path by verifying proper target variable reference.


Closes #206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved target URL resolution logic to intelligently select between CLI-provided targets and configuration base URLs, ensuring more consistent behavior.
  * CORS probe execution is now properly conditional and only runs when a valid target URL has been resolved.
  * HTTP requests for CORS analysis now consistently use the resolved target URL instead of the original input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->