### PR TITLE
Fixed ChainExecutor.execute_attack Causing Double Base URL (Closes #214)

### DIFF
--- a/chaos_kitten/brain/attack_chainer.py
+++ b/chaos_kitten/brain/attack_chainer.py
@@ -184,11 +184,10 @@ class ChainExecutor:
                 for var_name, var_value in variables.items():
                     path = path.replace(f"{{{var_name}}}", str(var_value))
                     
-                # Prepend base_url if path is relative
-                if base_url and path.startswith("/"):
-                    full_url = f"{base_url.rstrip('/')}{path}"
-                else:
-                    full_url = path
+                # Pass the relative path directly to the executor.
+                # The executor's httpx client is already configured with the
+                # base_url, so prepending it here would cause a double-prefix
+                # (e.g. http://example.com/http://example.com/api/users).
                     
                 # Prepare payload with injected variables
                 payload = {}
@@ -199,7 +198,7 @@ class ChainExecutor:
                         logger.warning(f"Missing variable '{var_name}' for step {i}, payload may be incomplete")
                         
                 # Execute attack
-                response = await self.executor.execute_attack(method, full_url, payload)
+                response = await self.executor.execute_attack(method, path, payload)
                 
                 # Check for execution error
                 if response.get("error"):
@@ -228,7 +227,7 @@ class ChainExecutor:
                     "step_index": i,
                     "status": "success",
                     "step": step,
-                    "request": {"method": method, "path": full_url, "payload": payload},
+                    "request": {"method": method, "path": path, "payload": payload},
                     "response": response
                 })
             except Exception as e:


### PR DESCRIPTION
Closes #214

Fix: ChainExecutor.execute_attack Causes Double Base URL (Issue 214)

Bug Description

In chaos_kitten/brain/attack_chainer.py, the execute_chain method was constructing a full URL by prepending base_url to the endpoint path before passing it to Executor.execute_attack(). However, the Executor class initializes its httpx.AsyncClient with base_url already configured, which means the client automatically prepends the base URL to any path it receives. This resulted in the base URL being prepended twice, producing malformed URLs like http://example.com/http://example.com/api/v1/users.

Root Cause

The ChainExecutor.execute_chain() method had logic (lines 187-191) that built a full_url by joining base_url and path before calling self.executor.execute_attack(method, full_url, payload). Since the Executor's internal httpx client already handles base URL resolution, this caused double prepending.

Fix

Removed the local full_url construction from execute_chain(). The relative path is now passed directly to the executor, which correctly resolves it against its own base_url. The request log entry was also updated to record the relative path instead of the previously constructed full_url.

Changes Made

- chaos_kitten/brain/attack_chainer.py
  - Removed the block that prepended base_url to path (lines 187-191)
  - Changed self.executor.execute_attack(method, full_url, payload) to self.executor.execute_attack(method, path, payload)
  - Updated the request log dict to use path instead of full_url

Before (broken)

  if base_url and path.startswith("/"):
      full_url = f"{base_url.rstrip('/')}{path}"
  else:
      full_url = path
  response = await self.executor.execute_attack(method, full_url, payload)

After (fixed)

  response = await self.executor.execute_attack(method, path, payload)

Testing

Existing test test_chain_executor in tests/test_attack_chainer.py already validates that the executor receives relative paths (/users, /users/42/orders, /orders/99) rather than full URLs, confirming the fix aligns with expected behavior.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL path handling to prevent incorrect prefixing in request execution, ensuring paths are properly formatted through the executor's base configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->