### PR TITLE
Fixed Swagger 2.0 Parsing Creates Invalid URLs If host Is Missing (Closes #216)

### DIFF
--- a/chaos_kitten/brain/openapi_parser.py
+++ b/chaos_kitten/brain/openapi_parser.py
@@ -340,7 +340,7 @@ class OpenAPIParser:
                 
                 servers.append(url)
         
-        elif 'host' in self.spec:
+        elif self.spec.get('swagger') == '2.0':
             # Swagger 2.0
             schemes = self.spec.get('schemes', ['https'])
             host = self.spec.get('host')
@@ -350,9 +350,13 @@ class OpenAPIParser:
             if base_path and not base_path.startswith('/'):
                 base_path = '/' + base_path
             
-            # Construct URLs for each scheme
-            for scheme in schemes:
-                servers.append(f"{scheme}://{host}{base_path}")
+            if host:
+                # Construct URLs for each scheme
+                for scheme in schemes:
+                    servers.append(f"{scheme}://{host}{base_path}")
+            else:
+                # If host is missing, fallback to basePath or '/'
+                servers.append(base_path if base_path else '/')
         
         return servers
 


### PR DESCRIPTION
Closes #216

Root Issue: OpenAPIParser.get_servers() used elif 'host' in self.spec: to detect Swagger 2.0 specs and construct server URLs. If host was missing (which is valid in Swagger 2.0), the method either returned an empty list or, if host was parsed as None, produced malformed URLs like https://None/api/v1.

Fix:

Updated the check to explicitly look for self.spec.get('swagger') == '2.0' rather than relying on the presence of the host key.
Added a conditional block when constructing the URL: if host is truthy, it builds scheme://host/base_path. If host is missing or None, it gracefully falls back to returning just the basePath (or /), defaulting to relative paths as expected by Swagger 2.0.
