### PR TITLE
ReconEngine Components Block the Async Event Loop (Closes#235)

### DIFF
--- a/chaos_kitten/brain/recon.py
+++ b/chaos_kitten/brain/recon.py
@@ -6,9 +6,7 @@ Performs subdomain enumeration, port scanning, and technology fingerprinting.
 import socket
 import logging
 import asyncio
-import subprocess
 import shutil
-import re
 from typing import List, Dict, Any
 from urllib.parse import urlparse
 import httpx
@@ -65,7 +63,7 @@ class ReconEngine:
 
         logger.info(f"Starting reconnaissance for domain: {domain}")
 
-        results = {
+        results: Dict[str, Any] = {
             "domain": domain,
             "subdomains": [],
             "services": {}, # host -> ports
@@ -80,16 +78,16 @@ class ReconEngine:
         # Add the main domain to the list for scanning
         targets = [domain] + subdomains 
 
-        # 2. Port Scanning
+        # 2. Port Scanning (async)
         if shutil.which("nmap"):
              for target in targets:
-                ports = self.scan_ports(target)
+                ports = await self.scan_ports(target)
                 if ports:
                     results["services"][target] = ports
         else:
              logger.info("Nmap not found. Skipping port scanning.")
 
-        # 3. Technology Fingerprinting
+        # 3. Technology Fingerprinting (async)
         for target in targets:
              # Construct URLs (try http and https)
              urls_to_check = []
@@ -102,7 +100,7 @@ class ReconEngine:
                  urls_to_check.append(f"https://{target}")
 
              for url in urls_to_check:
-                 tech = self.fingerprint_tech(url)
+                 tech = await self.fingerprint_tech(url)
                  if tech:
                      results["technologies"][url] = tech
 
@@ -121,10 +119,10 @@ class ReconEngine:
 
         logger.info(f"Brute-forcing {len(subdomain_words)} subdomains with concurrency {self.concurrency}...")
         
-        found_subdomains = []
+        found_subdomains: List[str] = []
         semaphore = asyncio.Semaphore(self.concurrency)
 
-        async def check_subdomain(sub: str):
+        async def check_subdomain(sub: str) -> None:
             full_domain = f"{sub}.{domain}"
             async with semaphore:
                 try:
@@ -149,29 +147,46 @@ class ReconEngine:
         
         return found_subdomains
 
-    def scan_ports(self, host: str) -> List[int]:
+    async def scan_ports(self, host: str) -> List[int]:
+        """Scan ports using nmap via ``asyncio.create_subprocess_exec``.
+
+        This avoids blocking the event loop during potentially long-running
+        nmap scans (the previous ``subprocess.run`` call could block for up
+        to 5 minutes).
         """
-        Scan ports using nmap.
-        """
-        open_ports = []
+        open_ports: List[int] = []
         cmd = ["nmap", "-T4", "--open", host]
-        
+
         if self.scan_depth == "fast":
             cmd.extend(["-F"])
         elif self.scan_depth == "deep":
             cmd.extend(["-p-"])
-        
+
         try:
             cmd.extend(["-oG", "-"])
-            
-            # Using subprocess with text=True for string output
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
-            output = result.stdout
-            
+
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(), timeout=300
+                )
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                logger.error(f"Nmap scan timed out for {host}")
+                return open_ports
+
+            output = stdout.decode("utf-8", errors="replace")
+
             # Parse nmap grepable output
             # Host: 127.0.0.1 ()	Ports: 80/open/tcp//http///, 443/open/tcp//https///
             for line in output.splitlines():
-                if "Ports:" in line and "Status: Up" not in line and "Host:" in line: 
+                if "Ports:" in line and "Status: Up" not in line and "Host:" in line:
                      # Extract ports part
                      try:
                          parts = line.split("Ports: ")[1]
@@ -183,24 +198,29 @@ class ReconEngine:
                      except IndexError:
                          continue
 
-        except subprocess.TimeoutExpired:
-             logger.error(f"Nmap scan timed out for {host}")
-        except subprocess.SubprocessError as e:
+        except OSError as e:
             logger.error(f"Nmap scan failed for {host}: {e}")
         except Exception as e:
             logger.error(f"Error parsing nmap output: {e}")
 
         return open_ports
 
-    def fingerprint_tech(self, url: str) -> Dict[str, Any]:
+    async def fingerprint_tech(self, url: str) -> Dict[str, Any]:
+        """Identify technologies from response headers and body.
+
+        Uses ``httpx.AsyncClient`` instead of the synchronous ``httpx.Client``
+        so that fingerprinting multiple URLs does not stall the event loop.
         """
-        Identify technologies from response headers and body using httpx.
-        """
-        fingerprints = {}
+        fingerprints: Dict[str, Any] = {}
         try:
-            logger.warning("TLS verification disabled for technology fingerprinting - man-in-the-middle risk in untrusted networks")
-            with httpx.Client(verify=False, timeout=self.timeout, follow_redirects=True) as client:
-                response = client.get(url)
+            logger.warning(
+                "TLS verification disabled for technology fingerprinting "
+                "- man-in-the-middle risk in untrusted networks"
+            )
+            async with httpx.AsyncClient(
+                verify=False, timeout=self.timeout, follow_redirects=True
+            ) as client:
+                response = await client.get(url)
                 headers = {k.lower(): v for k, v in response.headers.items()}
                 body = response.text.lower()
 
@@ -221,7 +241,7 @@ class ReconEngine:
                      if "csrftoken" in cookie.name: 
                          fingerprints.setdefault("frameworks", []).append("Django")
 
-                # 4. Body heurstics
+                # 4. Body heuristics
                 if 'content="wordpress"' in body:
                      fingerprints.setdefault("cms", []).append("WordPress")
                 if 'react' in body or 'react-dom' in body:
@@ -231,6 +251,5 @@ class ReconEngine:
 
         except httpx.RequestError as e:
             logger.debug(f"Could not connect to {url} for fingerprinting: {e}")
-            pass
             
         return fingerprints

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -17,14 +17,16 @@ for mod in [
 ]:
     sys.modules[mod] = MagicMock()
 
-import unittest
-from unittest.mock import patch, mock_open
+import asyncio
+import pytest
+from unittest.mock import patch, mock_open, AsyncMock
 import shutil
 import socket
 from chaos_kitten.brain.recon import ReconEngine
 
-class TestReconEngine(unittest.TestCase):
-    def setUp(self):
+
+class TestReconEngine:
+    def setup_method(self):
         self.config = {
             "target": {"base_url": "https://example.com"},
             "recon": {
@@ -38,15 +40,17 @@ class TestReconEngine(unittest.TestCase):
 
     def test_init_defaults(self):
         engine = ReconEngine({"target": {"base_url": "https://example.com"}})
-        self.assertFalse(engine.enabled)
-        self.assertEqual(engine.ports, [80, 443])
+        assert engine.enabled is False
+        assert engine.ports == [80, 443]
 
-    def test_run_disabled(self):
+    @pytest.mark.asyncio
+    async def test_run_disabled(self):
         self.engine.enabled = False
-        results = self.engine.run()
-        self.assertEqual(results, {})
+        results = await self.engine.run()
+        assert results == {}
 
-    def test_enumerate_subdomains(self):
+    @pytest.mark.asyncio
+    async def test_enumerate_subdomains(self):
         mock_file_content = "www\napi"
         with patch("builtins.open", mock_open(read_data=mock_file_content)):
             with patch("socket.gethostbyname") as mock_dns:
@@ -56,75 +60,121 @@ class TestReconEngine(unittest.TestCase):
                     raise socket.gaierror
                 mock_dns.side_effect = dns_side_effect
 
-                # Need to update wordlist path config or ensure open calls correct path
-                # Since we mock open, the path doesn't matter much as long as it opens something.
-                subs = self.engine.enumerate_subdomains("example.com")
-                self.assertIn("www.example.com", subs)
+                subs = await self.engine.enumerate_subdomains("example.com")
+                assert "www.example.com" in subs
                 # api.example.com raises gaierror, so it shouldn't be in subs
-                self.assertNotIn("api.example.com", subs)
+                assert "api.example.com" not in subs
 
-    @patch("shutil.which")
-    @patch("subprocess.run")
-    def test_scan_ports(self, mock_run, mock_which):
-        # Mock nmap existence
-        mock_which.return_value = "/usr/bin/nmap"
-        
-        # Mock nmap output
-        mock_result = MagicMock()
-        mock_result.stdout = "Host: 127.0.0.1 ()	Ports: 80/open/tcp//http///, 443/open/tcp//https///"
-        mock_run.return_value = mock_result
-        
-        # We need to make sure self.engine.scan_depth is what we expect
-        self.engine.scan_depth = "fast"
-        ports = self.engine.scan_ports("example.com")
-        
-        self.assertIn(80, ports)
-        self.assertIn(443, ports)
-        
-        # Verify arguments based on scan_depth="fast"
-        args = mock_run.call_args[0][0]
-        self.assertIn("-F", args)
+    @pytest.mark.asyncio
+    async def test_scan_ports(self):
+        """Test async scan_ports with mocked asyncio subprocess."""
+        nmap_output = "Host: 127.0.0.1 ()\tPorts: 80/open/tcp//http///, 443/open/tcp//https///"
 
-    @patch("httpx.Client")
-    def test_fingerprint_tech(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_client_cls.return_value.__enter__.return_value = mock_client
-        
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (
+            nmap_output.encode("utf-8"),
+            b"",
+        )
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            self.engine.scan_depth = "fast"
+            ports = await self.engine.scan_ports("example.com")
+
+        assert 80 in ports
+        assert 443 in ports
+        # Verify -F flag was included for fast scan
+        call_args = mock_exec.call_args[0]
+        assert "-F" in call_args
+
+    @pytest.mark.asyncio
+    async def test_scan_ports_timeout(self):
+        """Test that scan_ports handles timeout gracefully."""
+        mock_proc = AsyncMock()
+        mock_proc.communicate.side_effect = asyncio.TimeoutError()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            ports = await self.engine.scan_ports("example.com")
+
+        assert ports == []
+        mock_proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_scan_ports_deep(self):
+        """Test deep scan passes -p- flag."""
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"", b"")
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            self.engine.scan_depth = "deep"
+            await self.engine.scan_ports("example.com")
+
+        call_args = mock_exec.call_args[0]
+        assert "-p-" in call_args
+
+    @pytest.mark.asyncio
+    async def test_fingerprint_tech(self):
+        """Test async fingerprint_tech with mocked httpx.AsyncClient."""
         mock_response = MagicMock()
         mock_response.headers = {"Server": "nginx", "X-Powered-By": "PHP/7.4"}
         mock_response.text = '<html><body>Content="WordPress"</body></html>'
         cookie = MagicMock()
         cookie.name = "PHPSESSID"
-        # Ensure name attribute is set on mock object
         mock_response.cookies = [cookie]
-        
-        mock_client.get.return_value = mock_response
-        
-        tech = self.engine.fingerprint_tech("http://example.com")
-        
-        self.assertEqual(tech.get("server"), "nginx")
-        self.assertEqual(tech.get("powered_by"), "PHP/7.4")
-        self.assertIn("WordPress", tech.get("cms", []))
-        self.assertIn("PHP", tech.get("frameworks", []))
 
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            tech = await self.engine.fingerprint_tech("http://example.com")
+
+        assert tech.get("server") == "nginx"
+        assert tech.get("powered_by") == "PHP/7.4"
+        assert "WordPress" in tech.get("cms", [])
+        assert "PHP" in tech.get("frameworks", [])
+
+    @pytest.mark.asyncio
+    async def test_fingerprint_tech_connection_error(self):
+        """Test that fingerprint_tech handles connection errors gracefully."""
+        import httpx
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.RequestError("Connection refused")
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            tech = await self.engine.fingerprint_tech("http://example.com")
+
+        assert tech == {}
+
+    @pytest.mark.asyncio
     @patch("chaos_kitten.brain.recon.ReconEngine.enumerate_subdomains")
     @patch("chaos_kitten.brain.recon.ReconEngine.scan_ports")
     @patch("chaos_kitten.brain.recon.ReconEngine.fingerprint_tech")
     @patch("shutil.which")
-    def test_run_integration(self, mock_which, mock_fingerprint, mock_scan, mock_enum):
+    async def test_run_integration(self, mock_which, mock_fingerprint, mock_scan, mock_enum):
         mock_enum.return_value = ["www.example.com"]
-        mock_which.return_value = True # nmap exists
+        mock_which.return_value = True  # nmap exists
         mock_scan.return_value = [80]
         mock_fingerprint.return_value = {"server": "test"}
-        
-        results = self.engine.run()
-        
-        self.assertEqual(results["domain"], "example.com")
-        self.assertIn("www.example.com", results["subdomains"])
-        self.assertEqual(results["services"]["www.example.com"], [80])
-        # It should try http and https for port 80? Or just http since 80 is usually http
-        # My code uses port logic: 443 -> https, others -> http
-        self.assertIn("http://www.example.com:80", results["technologies"])
+
+        results = await self.engine.run()
+
+        assert results["domain"] == "example.com"
+        assert "www.example.com" in results["subdomains"]
+        assert results["services"]["www.example.com"] == [80]
+        assert "http://www.example.com:80" in results["technologies"]
+
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main([__file__])


### PR DESCRIPTION
Description
This PR fixes the async event loop blocking bug in `ReconEngine` (#235). The `scan_ports()` and `fingerprint_tech()` methods were synchronous, freezing the entire asyncio event loop during Nmap execution and HTTP fingerprinting.


 Changes

 `chaos_kitten/brain/recon.py`
- **`scan_ports()`**: Converted from blocking `subprocess.run` (up to 5-minute freeze) to `asyncio.create_subprocess_exec` with `asyncio.wait_for` timeout. On timeout, the nmap process is killed gracefully.
- **`fingerprint_tech()`**: Converted from synchronous `httpx.Client` to `httpx.AsyncClient`, allowing concurrent fingerprinting without stalling the event loop.
- **`run()`**: Updated to `await` both converted methods.
- Removed unused `subprocess` and `re` imports.
 `tests/test_recon.py`
- Rewritten for async: all tests use `pytest.mark.asyncio`.
- Mocks updated to use `AsyncMock` for subprocess and `httpx.AsyncClient`.
- Added new tests:
  - Timeout handling for `scan_ports` (verifies process kill on timeout)
  - Connection error handling for `fingerprint_tech`
  - Deep scan flag (`-p-`) verification

 Testing
```bash
pytest tests/test_recon.py -v
# 9 passed in 0.54s
```

Related Issue
Fixes #235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Upgraded core reconnaissance operations to asynchronous execution, improving system responsiveness during port scanning and technology detection tasks without blocking other processes.
  * Added comprehensive type annotations for enhanced code maintainability and type safety.

* **Tests**
  * Modernized the test infrastructure to support asynchronous testing patterns, with significantly expanded test coverage for all reconnaissance operations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->