### PR TITLE
KeyError - ChainExecutor.execute_chain Return Key Mismatch #266

### DIFF
--- a/chaos_kitten/brain/attack_chainer.py
+++ b/chaos_kitten/brain/attack_chainer.py
@@ -242,7 +242,7 @@ class ChainExecutor:
             
         return {
             "chain": chain,
-            "successful": results,
+            "results": results,
             "failed": errors,
             "partial_success": len(results) > 0 and len(errors) > 0
         }


### PR DESCRIPTION
Description
This PR addresses issue #266: `[BUG] KeyError - ChainExecutor.execute_chain Return Key Mismatch`.

The `ChainExecutor.execute_chain` method previously returned a dictionary where successful steps were stored under the key `successful`. However, the test suite in `tests/test_attack_chainer.py` expects the key to be `results`. To resolve this mismatch, the return dictionary in `ChainExecutor.execute_chain` has been updated to use the key `results`.

Changes Made
- Renamed the `successful` return key to `results` in the `ChainExecutor.execute_chain` method within `chaos_kitten/brain/attack_chainer.py`.
- Verified that tests in `tests/test_attack_chainer.py` now pass successfully without raising a `KeyError`.

Closes #266 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced adaptive fuzzing capability that dynamically generates and executes payloads based on real-time endpoint responses.

* **Breaking Changes**
  * Updated API response format: key renamed from "successful" to "results" in chain execution output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->