### PR TITLE
Spider Merge Logic Ignores New Methods on Existing Paths (Closes#270)

### DIFF
--- a/chaos_kitten/brain/orchestrator.py
+++ b/chaos_kitten/brain/orchestrator.py
@@ -182,9 +182,12 @@ async def plan_attacks(state: AgentState, app_config: Dict[str, Any]) -> Dict[st
                 spider_results = await spider.crawl()
                 spidered = spider.to_endpoint_dicts()
 
-                # Merge: only add paths not already covered by the spec
-                existing_paths = {ep["path"] for ep in endpoints}
-                new_endpoints = [ep for ep in spidered if ep["path"] not in existing_paths]
+                # Merge: only add (method, path) combinations not already covered by the spec
+                existing_endpoints = {(ep["method"], ep["path"]) for ep in endpoints}
+                new_endpoints = [
+                    ep for ep in spidered 
+                    if (ep["method"], ep["path"]) not in existing_endpoints
+                ]
                 endpoints.extend(new_endpoints)
 
                 if new_endpoints:


### PR DESCRIPTION
Description: The spider merge logic in orchestrator.py was previously ignoring dynamic API discovery results if the discovered path already existed in the OpenAPI spec. This failed to account for endpoints that share a path but use different HTTP methods (e.g., a spec only defining GET /api/data while a spider discovers POST /api/data).

Changes:

Updated the merge check in orchestrator.py to use a composite key of (method, path).
Replaced the simple path-based set check with a tuple-based check to correctly identify unique method/path combinations.
Verification:

Created and ran a reproduction test script tests/repro_issue_270.py which mocks a scenario where a spec contains GET /api/data and the spider discovers POST /api/data.
Verified that both endpoints are now correctly passed to the AttackPlanner.

Fixes: Closes #270

The changes have been pushed to origin/spidermerge. 