### PR TITLE
Shared Logger Name in Executor #271

### DIFF
--- a/chaos_kitten/paws/executor.py
+++ b/chaos_kitten/paws/executor.py
@@ -384,7 +384,7 @@ class Executor:
 
     def _setup_logging(self) -> None:
         """Setup request/response logging."""
-        self._logger = logging.getLogger(f"{__name__}.traffic")
+        self._logger = logging.getLogger(f"{__name__}.traffic.{id(self)}")
         self._logger.setLevel(logging.INFO)
         
         # Suppress httpx info logs to prevent leaking sensitive data or double logging


### PR DESCRIPTION
Description: All Executor instances were previously initializing a logger with the fixed name chaos_kitten.paws.executor.traffic. This caused overlapping log streams and issues with file handler cleanup during concurrent or multi-agent scans, as multiple instances were trying to manage the same logger object.

Changes:

Modified _setup_logging in executor.py to append id(self) to the logger name.
Ensures each Executor instance has a unique logger (e.g., chaos_kitten.paws.executor.traffic.140410423019216).
Verification:

Verified by running pytest tests/test_executor_logging_fixes.py::test_fix3_unique_logger_names, which now passes.
Confirmed that each instance indeed generates a unique logger name.

Fixes: Closes #271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance-specific logging to differentiate output between concurrent operations, enabling better debugging and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->